### PR TITLE
Remove dependence on auth config flag, add metric for http auth working

### DIFF
--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -671,7 +671,8 @@ class HTTPSClientAuthHandler(urllib2.HTTPSHandler):
         return httplib.HTTPSConnection(host, key_file=self.key_file, cert_file=self.cert_file, timeout=timeout)
 
 
-def fetch_url(es_url):
+#TODO remove eventually
+def fetch_url_old(es_url):
     # If tls is enabled, try doing an http request, but catch an exception so we can attempt a non-tls request
     # This is needed for migrating a cluster from http->https as tls will be enabled on some nodes that are running
     # es without authenticated http requests
@@ -705,7 +706,7 @@ def fetch_url(es_url):
             non_tls_response.close()
 
 
-def fetch_url_no_flag(es_url):
+def fetch_url(es_url):
     # Attempts to fetch both encrypted endpoint and unencrypted, regardless of flag
     # The config flag for http auth is not always indicative of the actual state of the auth plugin on the node
 

--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -771,6 +771,7 @@ def dispatch_is_http_tls_enabled():
             tls_response.close()
 
     # Custom stat to measure whether HTTP auth is enabled. Will be set based on success of http request
+    print("status of http auth is %s" % is_tls_enabled)
     http_tls_stat = Stat("gauge", "nodes.%s.http.auth.enabled")
     dispatch_stat(is_tls_enabled, 'node.http.auth.enabled', http_tls_stat)
 


### PR DESCRIPTION
This PR does 2 things:

1. Removes dependence on the auth config flag to work in all situations. Previously, it that flag was set to false but http auth was still active, metrics would not be reported. In the case of slowly rolling back auth on a cluster, many nodes would not report metrics, and would be bad. This new method _always_ tries auth request first, then if that fails attempts a non auth request, very similar to how `hs_es_curl` works.

2. Adds new metric for http auth tracking. Every reporting cycle, collectd attempts an http ES request with auth. If it succeeds, it reports this metric as 1. If it fails, reports as 0. This will be useful for monitoring what nodes actually have http auth enabled, and what quantity of nodes in a cluster have auth. 

Tested and working.